### PR TITLE
Add hero video background

### DIFF
--- a/src/components/sections/Hero.astro
+++ b/src/components/sections/Hero.astro
@@ -9,6 +9,16 @@ const { name, tagline, links = [] } = Astro.props;
 ---
 
 <section class="hero zone-dark">
+  <video
+    class="hero__video"
+    autoplay
+    muted
+    loop
+    playsinline
+    aria-hidden="true"
+  >
+    <source src="/video/hero1.webm" type="video/webm" />
+  </video>
   <div class="hero__content">
     <h1 class="hero__name">{name}</h1>
     <p class="hero__tagline">{tagline}</p>
@@ -33,15 +43,28 @@ const { name, tagline, links = [] } = Astro.props;
 
 <style>
   .hero {
+    position: relative;
     display: flex;
     align-items: center;
     justify-content: center;
     min-height: 100vh;
     min-height: 100dvh;
     padding-inline: var(--padding-container);
+    overflow: hidden;
+  }
+
+  .hero__video {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    z-index: 0;
   }
 
   .hero__content {
+    position: relative;
+    z-index: 1;
     text-align: center;
     max-width: var(--width-container);
   }


### PR DESCRIPTION
Replace solid black hero background with looping video (hero1.webm). Video covers the full viewport behind the text content.