### PR TITLE
Align hero info with Experience section heading

### DIFF
--- a/src/components/sections/Hero.astro
+++ b/src/components/sections/Hero.astro
@@ -38,7 +38,9 @@
   .hero__info {
     position: absolute;
     bottom: var(--space-8);
-    left: var(--padding-container);
+    /* Align with the Experience section header: centered 1080px container +
+       container padding − section-header's -32px negative margin. */
+    left: calc(max(0px, (100% - var(--width-container)) / 2) + var(--padding-container) - var(--space-8));
     z-index: 1;
   }
 


### PR DESCRIPTION
Position .hero__info using the same computed left edge as the Experience section header so "Carl Broker" lines up vertically with "Experience" below it.