### PR TITLE
Align hero and Experience heading with timeline dot

### DIFF
--- a/src/components/sections/Hero.astro
+++ b/src/components/sections/Hero.astro
@@ -38,7 +38,9 @@
   .hero__info {
     position: absolute;
     bottom: var(--space-8);
-    left: var(--padding-container);
+    /* Align with the Experience section header: centered 1080px container +
+       container padding − section-header's -32px negative margin. */
+    left: calc(max(0px, (100% - var(--width-container)) / 2) + var(--padding-container) - var(--space-8));
     z-index: 1;
   }
 

--- a/src/components/sections/Hero.astro
+++ b/src/components/sections/Hero.astro
@@ -38,9 +38,9 @@
   .hero__info {
     position: absolute;
     bottom: var(--space-8);
-    /* Align with the Experience section header: centered 1080px container +
-       container padding − section-header's -32px negative margin. */
-    left: calc(max(0px, (100% - var(--width-container)) / 2) + var(--padding-container) - var(--space-8));
+    /* Align with the timeline dot in the Experience section below:
+       centered 1080px container + container padding + 154px dot offset. */
+    left: calc(max(0px, (100% - var(--width-container)) / 2) + var(--padding-container) + 154px);
     z-index: 1;
   }
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -156,7 +156,8 @@ const contactLinks = [
 
   :global(.experience-section) .section-header {
     margin-bottom: var(--space-6);
-    margin-left: -32px;
+    /* Align heading with the timeline dot (154px from container content edge). */
+    margin-left: 154px;
   }
 
   /* Shared section header */


### PR DESCRIPTION
## Summary
- Position the hero info (`Carl Broker`, tagline, location) so its left edge lines up with the timeline dot's left edge.
- Move the Experience section heading to the same x-position.

## Test plan
- [ ] `npm run dev` and confirm the hero text, the word "Experience", and the green timeline dot all share the same left edge on wide viewports.
- [ ] Check narrow viewports (≤640px) for reasonable layout — timeline switches to a single-column layout at that breakpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)