### PR TITLE
Site polish: footer, SEO/social meta, hero CTAs, and writing navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ live version is the better way in:
 
 ## About me
 
-I'm an **Agentic AI Engineer at IBM**, based in Duluth, Minnesota. My work sits
+I'm an **Advisory AI Engineer at IBM**, based in Duluth, Minnesota. My work sits
 at the intersection of agentic AI, retrieval systems, LLM platforms, and
 production engineering — designing systems where models, tools, and data work
 together to solve real problems.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Project and writing entries live in `src/content/projects/` and
 
 ### Deployment
 
-Static build deployed to GitHub Pages from `main` via GitHub Actions.
+Static build deployed to GitHub Pages from `master` via GitHub Actions.
 
 ---
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /

--- a/src/components/global/SiteFooter.astro
+++ b/src/components/global/SiteFooter.astro
@@ -1,15 +1,19 @@
 ---
+const base = import.meta.env.BASE_URL;
+const home = base.endsWith('/') ? base : `${base}/`;
+
 const siteLinks = [
-  { label: 'Projects', href: '#projects' },
-  { label: 'Writing', href: '#writing' },
-  { label: 'Experience', href: '#experience' },
-  { label: 'About', href: '#about' },
-  { label: 'Contact', href: '#contact' },
+  { label: 'Experience', href: `${home}#experience` },
+  { label: 'Projects', href: `${home}#projects` },
+  { label: 'Writing', href: `${home}#writing` },
+  { label: 'About', href: `${home}#about` },
+  { label: 'Contact', href: `${home}#contact` },
 ];
 
 const externalLinks = [
   { label: 'GitHub', href: 'https://github.com/cbroker1' },
   { label: 'LinkedIn', href: 'https://www.linkedin.com/in/carl-broker-70211646/' },
+  { label: 'Resume', href: `${home}resume/resume_revised_pdf.pdf` },
 ];
 
 const year = new Date().getFullYear();
@@ -18,7 +22,10 @@ const year = new Date().getFullYear();
 <footer class="site-footer zone-dark">
   <div class="site-footer__inner container--wide">
     <div class="site-footer__brand">
-      <a href="#" class="site-footer__logo nav-link">CB</a>
+      <a href={home} class="site-footer__logo nav-link">CB</a>
+      <p class="site-footer__tagline">
+        AI systems that are meant to be used, not just demoed.
+      </p>
     </div>
 
     <div class="site-footer__col">
@@ -51,7 +58,7 @@ const year = new Date().getFullYear();
 
   <div class="site-footer__bottom container--wide">
     <span class="site-footer__copyright">
-      &copy; {year}
+      &copy; {year} Carl Broker &middot; Duluth, Minnesota
     </span>
   </div>
 </footer>
@@ -73,7 +80,16 @@ const year = new Date().getFullYear();
 
   .site-footer__brand {
     display: flex;
+    flex-direction: column;
     align-items: flex-start;
+    gap: var(--space-3);
+  }
+
+  .site-footer__tagline {
+    font-size: var(--text-sm);
+    line-height: var(--leading-normal);
+    color: var(--color-text-muted-dark);
+    max-width: 28ch;
   }
 
   .site-footer__logo {

--- a/src/components/global/SiteHeader.astro
+++ b/src/components/global/SiteHeader.astro
@@ -136,6 +136,14 @@ const navLinks = [
     transition: transform var(--duration-normal) var(--ease-out);
   }
 
+  .site-header__mobile-toggle[aria-expanded="true"] .hamburger-line:nth-child(1) {
+    transform: translateY(4px) rotate(45deg);
+  }
+
+  .site-header__mobile-toggle[aria-expanded="true"] .hamburger-line:nth-child(2) {
+    transform: translateY(-4px) rotate(-45deg);
+  }
+
   /* Mobile menu */
   .mobile-menu {
     background-color: rgba(10, 10, 10, 0.95);

--- a/src/components/sections/Hero.astro
+++ b/src/components/sections/Hero.astro
@@ -16,7 +16,7 @@ const home = base.endsWith('/') ? base : `${base}/`;
   </video>
   <div class="hero__info">
     <h1 class="hero__name">Carl Broker</h1>
-    <p class="hero__detail">Agentic AI Engineer, IBM</p>
+    <p class="hero__detail">Advisory AI Engineer, IBM</p>
     <p class="hero__detail">Duluth, Minnesota</p>
     <p class="hero__tagline">
       I build AI systems that are meant to be used, not just demoed.

--- a/src/components/sections/Hero.astro
+++ b/src/components/sections/Hero.astro
@@ -1,4 +1,6 @@
 ---
+const base = import.meta.env.BASE_URL;
+const home = base.endsWith('/') ? base : `${base}/`;
 ---
 
 <section class="hero">
@@ -16,8 +18,38 @@
     <h1 class="hero__name">Carl Broker</h1>
     <p class="hero__detail">Agentic AI Engineer, IBM</p>
     <p class="hero__detail">Duluth, Minnesota</p>
+    <p class="hero__tagline">
+      I build AI systems that are meant to be used, not just demoed.
+    </p>
+    <ul class="hero__links">
+      <li>
+        <a href="#projects" class="hero__link">See the work &darr;</a>
+      </li>
+      <li>
+        <a
+          href={`${home}resume/resume_revised_pdf.pdf`}
+          class="hero__link"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Resume &nearr;
+        </a>
+      </li>
+    </ul>
   </div>
+  <a class="hero__scroll" href="#experience" aria-label="Scroll to experience">
+    <span class="hero__scroll-arrow" aria-hidden="true">&darr;</span>
+  </a>
 </section>
+
+<script>
+  // Respect reduced-motion: hold the video on its first frame.
+  const video = document.querySelector<HTMLVideoElement>('.hero__video');
+  if (video && window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    video.removeAttribute('autoplay');
+    video.pause();
+  }
+</script>
 
 <style>
   .hero {
@@ -25,6 +57,9 @@
     height: 100vh;
     height: 100dvh;
     overflow: hidden;
+    /* Fallback close to the video's tone so the dark text stays
+       readable if the video fails to load. */
+    background-color: var(--color-bg-light);
   }
 
   .hero__video {
@@ -62,6 +97,121 @@
     margin-top: var(--space-1);
   }
 
+  .hero__tagline {
+    margin-top: var(--space-6);
+    margin-left: auto;
+    max-width: 30ch;
+    font-size: var(--text-base);
+    line-height: var(--leading-normal);
+    color: rgba(26, 26, 26, 0.75);
+  }
+
+  .hero__links {
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--space-6);
+    margin-top: var(--space-6);
+  }
+
+  .hero__link {
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    letter-spacing: var(--tracking-wide);
+    color: #1a1a1a;
+    padding-bottom: 3px;
+    background-image: linear-gradient(var(--color-accent-dark), var(--color-accent-dark));
+    background-position: 0 100%;
+    background-repeat: no-repeat;
+    background-size: 100% 1px;
+    transition:
+      background-size var(--duration-normal) var(--ease-out-expo),
+      color var(--duration-fast) var(--ease-out);
+  }
+
+  .hero__link:hover {
+    color: var(--color-accent-dark);
+    background-size: 100% 2px;
+  }
+
+  /* Scroll cue */
+  .hero__scroll {
+    position: absolute;
+    left: 50%;
+    bottom: var(--space-8);
+    transform: translateX(-50%);
+    z-index: 1;
+    padding: var(--space-2);
+    font-family: var(--font-mono);
+    font-size: var(--text-lg);
+    color: rgba(26, 26, 26, 0.55);
+    opacity: 0;
+    animation: hero-fade 0.9s var(--ease-out) 1.4s forwards;
+    transition: color var(--duration-fast) var(--ease-out);
+  }
+
+  .hero__scroll:hover {
+    color: #1a1a1a;
+  }
+
+  .hero__scroll-arrow {
+    display: block;
+    animation: hero-bob 2.4s ease-in-out 2.4s infinite;
+  }
+
+  /* Entrance: staggered rise, matching the site's reveal language */
+  .hero__name,
+  .hero__detail,
+  .hero__tagline,
+  .hero__links {
+    opacity: 0;
+    animation: hero-rise 0.9s var(--ease-out-expo) forwards;
+  }
+
+  .hero__name { animation-delay: 0.15s; }
+  .hero__detail:nth-of-type(1) { animation-delay: 0.3s; }
+  .hero__detail:nth-of-type(2) { animation-delay: 0.4s; }
+  .hero__tagline { animation-delay: 0.55s; }
+  .hero__links { animation-delay: 0.7s; }
+
+  @keyframes hero-rise {
+    from {
+      opacity: 0;
+      transform: translateY(14px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  @keyframes hero-fade {
+    to {
+      opacity: 1;
+    }
+  }
+
+  @keyframes hero-bob {
+    0%, 100% { transform: translateY(0); }
+    50% { transform: translateY(6px); }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .hero__name,
+    .hero__detail,
+    .hero__tagline,
+    .hero__links,
+    .hero__scroll,
+    .hero__scroll-arrow {
+      opacity: 1;
+      transform: none;
+      animation: none;
+    }
+
+    .hero__scroll {
+      transform: translateX(-50%);
+    }
+  }
+
   @media (max-width: 768px) {
     .hero__info {
       top: auto;
@@ -72,6 +222,21 @@
 
     .hero__name {
       font-size: var(--text-2xl);
+    }
+
+    .hero__tagline {
+      margin-top: var(--space-4);
+      max-width: 26ch;
+      font-size: var(--text-sm);
+    }
+
+    .hero__links {
+      margin-top: var(--space-4);
+    }
+
+    /* The info block sits at the bottom on mobile — the cue would collide. */
+    .hero__scroll {
+      display: none;
     }
   }
 </style>

--- a/src/content/writing/nvidia-tensorrt-llm-a6000.md
+++ b/src/content/writing/nvidia-tensorrt-llm-a6000.md
@@ -12,8 +12,6 @@ featured: true
 draft: false
 ---
 
-# TensorRT-LLM on an RTX A6000: Part 1 — GPU Passthrough, KV Cache, and Single-GPU Serving
-
 ## Why I Built This
 
 I recently met with an NVIDIA AI Solution Architect who recommended that I learn four areas: TensorRT, TensorRT-LLM, Dynamo, and parallelism strategies. Rather than only reading documentation, I wanted to build a small hands-on project that I could explain clearly in an interview.

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,14 +1,21 @@
 ---
 import SiteHeader from '../components/global/SiteHeader.astro';
+import SiteFooter from '../components/global/SiteFooter.astro';
 import '../styles/global.css';
 
 interface Props {
   title: string;
   description?: string;
+  ogType?: 'website' | 'article';
 }
 
-const { title, description = 'Projects, writing, and experiments.' } = Astro.props;
+const {
+  title,
+  description = 'Projects, writing, and experiments.',
+  ogType = 'website',
+} = Astro.props;
 const base = import.meta.env.BASE_URL;
+const canonical = Astro.site ? new URL(Astro.url.pathname, Astro.site).href : undefined;
 ---
 
 <!doctype html>
@@ -17,7 +24,20 @@ const base = import.meta.env.BASE_URL;
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content={description} />
+    <meta name="author" content="Carl Broker" />
+    <meta name="theme-color" content="#0a0a0a" />
+    {canonical && <link rel="canonical" href={canonical} />}
     <link rel="icon" type="image/svg+xml" href={`${base}favicon.svg`} />
+
+    <!-- Social sharing -->
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:type" content={ogType} />
+    {canonical && <meta property="og:url" content={canonical} />}
+    <meta property="og:site_name" content="Carl Broker" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={description} />
 
     <!-- Fonts: Inter + Geist Mono -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -30,10 +50,20 @@ const base = import.meta.env.BASE_URL;
     <title>{title}</title>
   </head>
   <body>
+    <a class="skip-link" href="#main-content">Skip to content</a>
     <SiteHeader />
-    <main>
+    <main id="main-content">
       <slot />
     </main>
+    <SiteFooter />
+    <noscript>
+      <style>
+        .reveal {
+          opacity: 1;
+          transform: none;
+        }
+      </style>
+    </noscript>
     <script>
       const observer = new IntersectionObserver(
         (entries) => {

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,82 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+
+const base = import.meta.env.BASE_URL;
+const home = base.endsWith('/') ? base : `${base}/`;
+---
+
+<BaseLayout title="404 — Page not found" description="This page doesn't exist.">
+  <section class="not-found zone-dark">
+    <div class="container not-found__inner">
+      <p class="not-found__code" aria-hidden="true">404</p>
+      <h1 class="not-found__title">This page doesn't exist.</h1>
+      <p class="not-found__hint">
+        The link may be old, or the page may have moved.
+      </p>
+      <ul class="not-found__links">
+        <li><a href={home}>&larr; Back home</a></li>
+        <li><a href={`${home}#projects`}>Projects</a></li>
+        <li><a href={`${home}#writing`}>Writing</a></li>
+      </ul>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .not-found {
+    display: grid;
+    place-items: center;
+    min-height: calc(100dvh - 40px);
+    padding-block: var(--space-section);
+  }
+
+  .not-found__inner {
+    text-align: center;
+  }
+
+  .not-found__code {
+    font-family: var(--font-mono);
+    font-size: var(--text-7xl);
+    font-weight: var(--weight-medium);
+    letter-spacing: var(--tracking-wide);
+    color: var(--color-accent);
+    opacity: 0.5;
+    line-height: var(--leading-none);
+  }
+
+  .not-found__title {
+    margin-top: var(--space-6);
+    font-size: var(--text-3xl);
+    font-weight: var(--weight-normal);
+  }
+
+  .not-found__hint {
+    margin-top: var(--space-4);
+    color: var(--color-text-muted-dark);
+  }
+
+  .not-found__links {
+    display: flex;
+    justify-content: center;
+    gap: var(--space-8);
+    margin-top: var(--space-12);
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    letter-spacing: var(--tracking-wide);
+  }
+
+  @media (max-width: 640px) {
+    .not-found__code {
+      font-size: var(--text-5xl);
+    }
+
+    .not-found__title {
+      font-size: var(--text-2xl);
+    }
+
+    .not-found__links {
+      flex-direction: column;
+      gap: var(--space-4);
+    }
+  }
+</style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -40,11 +40,14 @@ const { Content: AboutContent } = await render(aboutEntry);
 const contactLinks = [
   { label: 'GitHub', href: 'https://github.com/cbroker1' },
   { label: 'LinkedIn', href: 'https://www.linkedin.com/in/carl-broker-70211646/' },
-  { label: 'Resume', href: '/resume/resume_revised_pdf.pdf' },
+  { label: 'Resume', href: `${base}resume/resume_revised_pdf.pdf` },
 ];
 ---
 
-<BaseLayout title="CB — Projects, Writing, Experiments">
+<BaseLayout
+  title="Carl Broker — Agentic AI Engineer"
+  description="Carl Broker is an agentic AI engineer at IBM building multi-agent systems, retrieval pipelines, and production LLM workflows. Projects, writing, and experiments."
+>
   <!-- Section 1: Hero (video only, full viewport) -->
   <Hero />
 
@@ -53,6 +56,9 @@ const contactLinks = [
     <div id="experience" class="anchor-offset"></div>
     <div class="section-header reveal">
       <h2 class="section-header__title">Experience</h2>
+      <p class="section-header__subtitle">
+        From neuroscience research to enterprise AI engineering.
+      </p>
     </div>
     <Timeline entries={experienceEntry.data.entries} />
   </SectionWrapper>
@@ -62,6 +68,9 @@ const contactLinks = [
     <div id="projects" class="anchor-offset"></div>
     <div class="section-header reveal">
       <h2 class="section-header__title">Projects</h2>
+      <p class="section-header__subtitle section-header__subtitle--on-dark">
+        AI systems, software, experiments, and tools.
+      </p>
     </div>
     <div class="project-grid reveal-stagger">
       {allProjects.map((project) => (
@@ -87,6 +96,9 @@ const contactLinks = [
     <div id="writing" class="anchor-offset"></div>
     <div class="section-header reveal">
       <h2 class="section-header__title">Writing</h2>
+      <p class="section-header__subtitle">
+        Build logs, benchmarks, and lessons from real systems.
+      </p>
     </div>
     <ul class="writing-list reveal">
       {allPosts.map((post) => (
@@ -121,6 +133,10 @@ const contactLinks = [
     <div id="contact" class="anchor-offset"></div>
     <div class="contact-section reveal">
       <h2 class="contact-section__heading">Let's connect.</h2>
+      <p class="contact-section__pitch">
+        If you're building something that needs an AI engineer who cares
+        whether the system actually works — get in touch.
+      </p>
       <ul class="contact-row">
         {contactLinks.map((link) => (
           <li>
@@ -168,6 +184,17 @@ const contactLinks = [
   .section-header__title {
     font-size: var(--text-2xl);
     font-weight: var(--weight-semibold);
+  }
+
+  .section-header__subtitle {
+    margin-top: var(--space-2);
+    font-size: var(--text-base);
+    line-height: var(--leading-normal);
+    color: var(--color-text-muted-light);
+  }
+
+  .section-header__subtitle--on-dark {
+    color: var(--color-text-muted-dark);
   }
 
   /* Project grid */
@@ -264,7 +291,16 @@ const contactLinks = [
   .contact-section__heading {
     font-size: var(--text-3xl);
     font-weight: var(--weight-normal);
+    margin-bottom: var(--space-4);
+  }
+
+  .contact-section__pitch {
+    max-width: 52ch;
+    margin-inline: auto;
     margin-bottom: var(--space-8);
+    font-size: var(--text-base);
+    line-height: var(--leading-normal);
+    color: var(--color-text-muted-dark);
   }
 
   .contact-row {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -45,8 +45,8 @@ const contactLinks = [
 ---
 
 <BaseLayout
-  title="Carl Broker — Agentic AI Engineer"
-  description="Carl Broker is an agentic AI engineer at IBM building multi-agent systems, retrieval pipelines, and production LLM workflows. Projects, writing, and experiments."
+  title="Carl Broker — Advisory AI Engineer"
+  description="Carl Broker is an Advisory AI Engineer at IBM building multi-agent systems, retrieval pipelines, and production LLM workflows. Projects, writing, and experiments."
 >
   <!-- Section 1: Hero (video only, full viewport) -->
   <Hero />

--- a/src/pages/writing/[id].astro
+++ b/src/pages/writing/[id].astro
@@ -14,6 +14,19 @@ export async function getStaticPaths() {
 const { post } = Astro.props;
 const { Content } = await render(post);
 
+const base = import.meta.env.BASE_URL;
+
+// Estimated reading time from the raw markdown body (~220 wpm).
+const wordCount = post.body ? post.body.split(/\s+/).filter(Boolean).length : 0;
+const readingTime = Math.max(1, Math.round(wordCount / 220));
+
+// Older/newer navigation across all published posts.
+const allPosts = (await getCollection('writing', ({ data }) => !data.draft))
+  .sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
+const postIndex = allPosts.findIndex((p) => p.id === post.id);
+const newerPost = postIndex > 0 ? allPosts[postIndex - 1] : null;
+const olderPost = postIndex < allPosts.length - 1 ? allPosts[postIndex + 1] : null;
+
 function formatDate(date: Date): string {
   return date.toLocaleDateString('en-US', {
     year: 'numeric',
@@ -23,10 +36,13 @@ function formatDate(date: Date): string {
 }
 ---
 
-<BaseLayout title={post.data.title} description={post.data.description}>
+<BaseLayout title={post.data.title} description={post.data.description} ogType="article">
   <SectionWrapper variant="light" width="content">
     <header class="post-header">
-      <p class="post-header__date">{formatDate(post.data.date)}</p>
+      <a href={`${base}writing`} class="post-header__back">&larr; All writing</a>
+      <p class="post-header__date">
+        {formatDate(post.data.date)} &middot; {readingTime} min read
+      </p>
       <h1 class="post-header__title">{post.data.title}</h1>
       {post.data.tags.length > 0 && (
         <ul class="post-header__tags">
@@ -40,6 +56,27 @@ function formatDate(date: Date): string {
     <article class="prose">
       <Content />
     </article>
+
+    {(olderPost || newerPost) && (
+      <nav class="post-nav" aria-label="More writing">
+        <div class="post-nav__cell">
+          {olderPost && (
+            <a href={`${base}writing/${olderPost.id}`} class="post-nav__link">
+              <span class="post-nav__label">&larr; Older</span>
+              <span class="post-nav__title">{olderPost.data.title}</span>
+            </a>
+          )}
+        </div>
+        <div class="post-nav__cell post-nav__cell--right">
+          {newerPost && (
+            <a href={`${base}writing/${newerPost.id}`} class="post-nav__link">
+              <span class="post-nav__label">Newer &rarr;</span>
+              <span class="post-nav__title">{newerPost.data.title}</span>
+            </a>
+          )}
+        </div>
+      </nav>
+    )}
   </SectionWrapper>
 </BaseLayout>
 
@@ -47,6 +84,20 @@ function formatDate(date: Date): string {
   .post-header {
     padding-top: var(--space-section-lg);
     margin-bottom: var(--space-component);
+  }
+
+  .post-header__back {
+    display: inline-block;
+    margin-bottom: var(--space-8);
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    color: var(--color-text-muted-light);
+    letter-spacing: var(--tracking-wide);
+    transition: color var(--duration-fast) var(--ease-out);
+  }
+
+  .post-header__back:hover {
+    color: var(--color-accent-dark);
   }
 
   .post-header__date {
@@ -81,9 +132,65 @@ function formatDate(date: Date): string {
     border-radius: 4px;
   }
 
+  /* Older/newer navigation */
+  .post-nav {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--space-8);
+    margin-top: var(--space-16);
+    padding-top: var(--space-8);
+    border-top: 1px solid var(--color-border-light);
+  }
+
+  .post-nav__cell--right {
+    text-align: right;
+  }
+
+  .post-nav__link {
+    display: inline-flex;
+    flex-direction: column;
+    gap: var(--space-2);
+  }
+
+  .post-nav__cell--right .post-nav__link {
+    align-items: flex-end;
+  }
+
+  .post-nav__label {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--color-text-muted-light);
+    letter-spacing: var(--tracking-wide);
+  }
+
+  .post-nav__title {
+    font-size: var(--text-sm);
+    font-weight: var(--weight-medium);
+    line-height: var(--leading-snug);
+    color: var(--color-text-on-light);
+    transition: color var(--duration-fast) var(--ease-out);
+  }
+
+  .post-nav__link:hover .post-nav__title {
+    color: var(--color-accent-dark);
+  }
+
   @media (max-width: 768px) {
     .post-header__title {
       font-size: var(--text-3xl);
+    }
+
+    .post-nav {
+      grid-template-columns: 1fr;
+      gap: var(--space-6);
+    }
+
+    .post-nav__cell--right {
+      text-align: left;
+    }
+
+    .post-nav__cell--right .post-nav__link {
+      align-items: flex-start;
     }
   }
 </style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -162,6 +162,36 @@ button {
   background: none;
 }
 
+:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+
+/* ============================================
+   Skip Link (keyboard navigation)
+   ============================================ */
+
+.skip-link {
+  position: fixed;
+  top: -100px;
+  left: var(--space-4);
+  z-index: 200;
+  padding: var(--space-2) var(--space-4);
+  background-color: var(--color-bg-dark);
+  color: var(--color-accent);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  letter-spacing: var(--tracking-wide);
+  border: 1px solid var(--color-border-dark);
+  border-radius: 4px;
+  transition: top var(--duration-fast) var(--ease-out);
+}
+
+.skip-link:focus {
+  top: var(--space-4);
+}
+
 
 /* ============================================
    Base Typography


### PR DESCRIPTION
## Summary

A polish pass that finishes half-built pieces and sharpens how the site markets the work — no restyling, no new dependencies, and all copy reuses language already in the repo.

### Finished what was half-built
- `SiteFooter` existed but was never rendered — now on every page via `BaseLayout`, with base-aware links, a Resume link, tagline, and proper copyright
- Custom 404 page in the dark-zone style, plus `robots.txt`
- Skip-to-content link, `:focus-visible` styles, and a noscript fallback so `.reveal` content is visible without JS

### Marketing surface
- Canonical URL + Open Graph + Twitter card meta on every page (posts emit `og:type=article`), so shared links render properly
- Homepage title/description worth indexing: "Carl Broker — Advisory AI Engineer"
- Hero (video and layout untouched): positioning line, two quiet mono CTAs (See the work ↓ / Resume ↗), scroll cue, staggered entrance with `prefers-reduced-motion` handling, and a background fallback if the video fails to load
- Muted one-line subtitles under section headings; contact CTA now carries the README closing pitch

### Writing pages
- Reading time, "← All writing" back link, and older/newer post navigation (ties the TensorRT-LLM series together)
- Fixed Part 1 rendering its title twice (frontmatter title + body H1)

### Micro-fixes
- Mobile hamburger animates to an X
- README: deploys run from `master`, not `main`
- Role title updated to **Advisory AI Engineer** across hero, meta, and README (matches the experience timeline)

## Test plan
- [x] `npm run build` passes (15 pages, including `404.html`)
- [x] Served the production build and smoke-tested every route — all 200, custom 404 body confirmed
- [x] Verified footer, meta tags, hero additions, and post navigation in the built HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)